### PR TITLE
Null data pred

### DIFF
--- a/src/services/PredictionsService.js
+++ b/src/services/PredictionsService.js
@@ -301,7 +301,7 @@ export default class PredictionsService {
 
     // Whether an outbreak occured or was predicted
     const outbreakOcurred = outcomeSpots > 53;
-    const outbreakPredicted = predictions.prob53spots > 0.5;
+    const outbreakPredicted = predictions.prob53spots;
     return {
       forest: predictionOutputs.inputs.forest,
       predictions,


### PR DESCRIPTION
# Allows for predictions to return null

# Only merge after [this PR](https://github.com/dali-lab/pine-beetle-frontend/pull/274) has been merged
If there's not enough data to form a correct prediction, return a null prediction instead of the default prediction. 


- getPredictions endpoint now can return null predictions
-  Evaluate predictions now as carrissa specified


## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

