### PR TITLE
County dropdown hotfix

### DIFF
--- a/src/controllers/HistoricalController.js
+++ b/src/controllers/HistoricalController.js
@@ -29,7 +29,6 @@ const getHistoricalDataFilter = (queryFields) => {
   } else if (endDate !== undefined) {
     data = data.where('year').lte(endDate);
   }
-
   return data;
 };
 

--- a/src/router.js
+++ b/src/router.js
@@ -41,6 +41,7 @@ router.post('/getHistoricalsFilter', (req, res) => {
 // get all items with passed filter, then summarize based on year
 router.post('/getSummarizedDataByYearFilter', (req, res) => {
   const queryFields = req.body;
+  queryFields.endDate = '2021';
   historicalController.getHistoricalDataFilter(queryFields).then((data) => {
     const summarizedDataByYear = HistoricalService.filterDataByYear(queryFields, data);
     res.send(summarizedDataByYear);
@@ -51,6 +52,8 @@ router.post('/getSummarizedDataByYearFilter', (req, res) => {
 // get all items with passed filter, then summarize based on year
 router.post('/getSummarizedDataByLatLongFilter', (req, res) => {
   const queryFields = req.body;
+  queryFields.endDate = '2021';
+  queryFields.startDate = '2018';
   historicalController.getHistoricalDataFilter(queryFields).then((data) => {
     const summarizedDataByLatLong = HistoricalService.filterDataByLatLog(queryFields, data);
     res.send(summarizedDataByLatLong);

--- a/src/services/HistoricalService.js
+++ b/src/services/HistoricalService.js
@@ -1,4 +1,5 @@
 const findLatLongObject = (collection, lat, long) => {
+  return null
   for (const i in collection) {
     if (collection[i].latitude === lat && collection[i].longitude === long) {
       return i;
@@ -36,8 +37,10 @@ export default class HistoricalService {
     const endDate = queryFields.endDate;
 
     const summarizedDataByLatLong = [];
-
+    console.log(queryFields)
     for (const entry in data) {
+      console.log("-------------")
+      console.log(data[entry])
       const dataObject = JSON.parse(JSON.stringify(data[entry]));
       const lat = data[entry].latitude;
       const long = data[entry].longitude;
@@ -138,7 +141,6 @@ export default class HistoricalService {
 
     // summarize data by year
     const summarizedDataByYear = [];
-
     for (const entry in data) {
       const dataObject = JSON.parse(JSON.stringify(data[entry]));
       const year = data[entry].year;


### PR DESCRIPTION
Currently, the appropriate counties don't always appear in the dropdown because of missing data. We can still make predictions on the remaining data, the users just don't get the option. 

In order to fix the underlying problem would require SIGNIFICANT changes to the way the backend and frontend work, as well as fixing several known and difficult issues. 

Instead of doing that, I sacrificed some of the theoretical efficacy of the historical data display (which already doesn't work due to the aforementioned issues) in order to get predictions working tonight. I've made some small changes that allow the counties to be displayed, chosen, and make predictions on. 

In the meantime, the hotfix is deployed and functioning properly. 