### PR TITLE
Add routers for prediction collections

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -3,6 +3,8 @@ import RESPONSE_TYPES from './response-types.json';
 
 // names of collections in MongoDB Atlas
 const COLLECTION_NAMES = {
+  predictionsCounty: 'countypredictions',
+  predictionsRangerDistrict: 'rdpredictions',
   spots: 'spotdatas',
   summarizedCounty: 'summarizedcountytrappings',
   summarizedRangerDistrict: 'summarizedrangerdistricttrappings',

--- a/src/routers/county-predictions.js
+++ b/src/routers/county-predictions.js
@@ -1,0 +1,56 @@
+import { Router } from 'express';
+
+import {
+  generateResponse,
+  COLLECTION_NAMES,
+  RESPONSE_CODES,
+  RESPONSE_TYPES,
+} from '../constants';
+
+import {
+  specifiedQueryFetch,
+  queryFetch,
+} from '../utils';
+
+const countyPredictionsRouter = Router();
+
+// query items in collection
+countyPredictionsRouter.route('/')
+  .get(async (req, res) => {
+    const validQueryFields = [
+      'cleridPerDay',
+      'county',
+      'spbPerDay',
+      'state',
+      'trapCount',
+      'year',
+    ];
+
+    try {
+      const items = await queryFetch(COLLECTION_NAMES.predictionsCounty, req.query, validQueryFields);
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, items));
+    } catch (error) {
+      console.log(error);
+
+      res.status(RESPONSE_CODES.INTERNAL_ERROR.status).send(
+        generateResponse(RESPONSE_TYPES.INTERNAL_ERROR, error),
+      );
+    }
+  });
+
+// user specified query (allows for mongo-specific syntax)
+countyPredictionsRouter.route('/query')
+  .post(async (req, res) => {
+    try {
+      const items = await specifiedQueryFetch(COLLECTION_NAMES.predictionsCounty, req.body);
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, items));
+    } catch (error) {
+      console.log(error);
+
+      res.status(RESPONSE_CODES.INTERNAL_ERROR.status).send(
+        generateResponse(RESPONSE_TYPES.INTERNAL_ERROR, error),
+      );
+    }
+  });
+
+export default countyPredictionsRouter;

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -1,4 +1,6 @@
+import countyPredictions from './county-predictions';
 import healthcheck from './healthcheck';
+import rangerDistrictPredictions from './ranger-district-predictions';
 import spots from './spots';
 import summarizedCounty from './summarized-county';
 import summarizedRangerDistrict from './summarized-ranger-district';
@@ -6,7 +8,9 @@ import unsummarized from './unsummarized';
 import user from './user';
 
 export default {
+  'county-prediction': countyPredictions,
   healthcheck,
+  'rd-prediction': rangerDistrictPredictions,
   'spot-data': spots,
   'summarized-county-trapping': summarizedCounty,
   'summarized-rangerdistrict-trapping': summarizedRangerDistrict,

--- a/src/routers/ranger-district-predictions.js
+++ b/src/routers/ranger-district-predictions.js
@@ -1,0 +1,56 @@
+import { Router } from 'express';
+
+import {
+  generateResponse,
+  COLLECTION_NAMES,
+  RESPONSE_CODES,
+  RESPONSE_TYPES,
+} from '../constants';
+
+import {
+  specifiedQueryFetch,
+  queryFetch,
+} from '../utils';
+
+const rangerDistrictPredictionsRouter = Router();
+
+// query items in collection
+rangerDistrictPredictionsRouter.route('/')
+  .get(async (req, res) => {
+    const validQueryFields = [
+      'cleridPerDay',
+      'rangerDistrict',
+      'spbPerDay',
+      'state',
+      'trapCount',
+      'year',
+    ];
+
+    try {
+      const items = await queryFetch(COLLECTION_NAMES.predictionsRangerDistrict, req.query, validQueryFields);
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, items));
+    } catch (error) {
+      console.log(error);
+
+      res.status(RESPONSE_CODES.INTERNAL_ERROR.status).send(
+        generateResponse(RESPONSE_TYPES.INTERNAL_ERROR, error),
+      );
+    }
+  });
+
+// user specified query (allows for mongo-specific syntax)
+rangerDistrictPredictionsRouter.route('/query')
+  .post(async (req, res) => {
+    try {
+      const items = await specifiedQueryFetch(COLLECTION_NAMES.predictionsRangerDistrict, req.body);
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, items));
+    } catch (error) {
+      console.log(error);
+
+      res.status(RESPONSE_CODES.INTERNAL_ERROR.status).send(
+        generateResponse(RESPONSE_TYPES.INTERNAL_ERROR, error),
+      );
+    }
+  });
+
+export default rangerDistrictPredictionsRouter;


### PR DESCRIPTION
# Description

- Added routers for county and RD predictions
- Used same names/prefixes as the automation router

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update