### PR TITLE
Fix spot data county collection name

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -5,7 +5,7 @@ import RESPONSE_TYPES from './response-types.json';
 const COLLECTION_NAMES = {
   predictionsCounty: 'countypredictions',
   predictionsRangerDistrict: 'rdpredictions',
-  spotsCounty: 'spotdatacountys',
+  spotsCounty: 'spotdatacounties',
   spotsRangerDistrict: 'spotdatarangerdistricts',
   summarizedCounty: 'summarizedcountytrappings',
   summarizedRangerDistrict: 'summarizedrangerdistricttrappings',


### PR DESCRIPTION
# Description

Change spot data county collection name from `countys` to `counties`

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update