### PR TITLE
Do not send salted_password when getting all users

### DIFF
--- a/src/routers/user.js
+++ b/src/routers/user.js
@@ -22,7 +22,12 @@ userRouter.route('/')
   .get(requireAuth, async (_req, res) => {
     try {
       const items = await queryFetch(COLLECTION_NAMES.users);
-      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, items));
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, items.map((user) => {
+        return {
+          ...user,
+          salted_password: undefined,
+        };
+      })));
     } catch (error) {
       console.log(error);
 


### PR DESCRIPTION
# Description

No longer send `salted_password` when getting all users

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update