### PR TITLE
Fix wrong sublocation key name for pipeline functions

### DIFF
--- a/src/routers/summarized-county.js
+++ b/src/routers/summarized-county.js
@@ -111,8 +111,8 @@ summarizedCountyRouter.route('/aggregate/year')
     } = req.query;
 
     const pipeline = generateYearPipeline('county', {
-      county,
       endYear: parseInt(endYear, 10),
+      loc: county,
       startYear: parseInt(startYear, 10),
       state,
     });
@@ -140,8 +140,8 @@ summarizedCountyRouter.route('/aggregate/state')
     } = req.query;
 
     const pipeline = generateStatePipeline('county', {
-      county,
       endYear: parseInt(endYear, 10),
+      loc: county,
       startYear: parseInt(startYear, 10),
       state,
     });
@@ -169,8 +169,8 @@ summarizedCountyRouter.route('/aggregate/county')
     } = req.query;
 
     const pipeline = generateLocationPipeline('county', {
-      county,
       endYear: parseInt(endYear, 10),
+      loc: county,
       startYear: parseInt(startYear, 10),
       state,
     });

--- a/src/routers/summarized-ranger-district.js
+++ b/src/routers/summarized-ranger-district.js
@@ -113,7 +113,7 @@ summarizedRDRouter.route('/aggregate/year')
 
     const pipeline = generateYearPipeline('rangerDistrict', {
       endYear: parseInt(endYear, 10),
-      rangerDistrict,
+      loc: rangerDistrict,
       startYear: parseInt(startYear, 10),
       state,
     });
@@ -142,7 +142,7 @@ summarizedRDRouter.route('/aggregate/state')
 
     const pipeline = generateStatePipeline('rangerDistrict', {
       endYear: parseInt(endYear, 10),
-      rangerDistrict,
+      loc: rangerDistrict,
       startYear: parseInt(startYear, 10),
       state,
     });
@@ -171,7 +171,7 @@ summarizedRDRouter.route('/aggregate/rangerDistrict')
 
     const pipeline = generateLocationPipeline('rangerDistrict', {
       endYear: parseInt(endYear, 10),
-      rangerDistrict,
+      loc: rangerDistrict,
       startYear: parseInt(startYear, 10),
       state,
     });


### PR DESCRIPTION
# Description

Pipeline function calls were passing `county` instead of `loc` key name in filter object

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update