### PR TITLE
fix: fix removing image when post update was made without changing an image

### DIFF
--- a/src/controllers/blog.js
+++ b/src/controllers/blog.js
@@ -111,10 +111,12 @@ export const updateBlogPost = async (id, fields, uploadedFile) => {
   try {
     const postId = new mongoose.Types.ObjectId(id);
 
-    await Blog.updateOne(
-      { _id: postId },
-      { ...fields, image: uploadedFile?.path || null },
-    );
+    if (uploadedFile) {
+      const imagePath = getFilePath(uploadedFile?.path);
+      await Blog.updateOne({ _id: postId }, { ...fields, image: imagePath });
+    } else {
+      await Blog.updateOne({ _id: postId }, fields);
+    }
 
     const blogPost = await Blog.findById(postId);
 


### PR DESCRIPTION
# Description
Fixes a bug causing image to be removed from the database when blog post was updated without changing an image.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [No ticket](Link)
