### PR TITLE
feat: add counties/results endpoint for results comparison

### DIFF
--- a/docs/SUMMARIZED-COUNTY.md
+++ b/docs/SUMMARIZED-COUNTY.md
@@ -117,3 +117,13 @@ User can filter the data with the following query params:
 - `endYear`
 - `isHistorical` -- whether or not to filter on just historical data
 - `isPrediction` -- whether or not to filter on just prediction data
+
+## `GET /summarized-county/counties/results`
+
+Returns a list of sorted county names represented in the data.
+
+User can filter the data with the following query params:
+
+- `state`
+- `year`
+- `county`

--- a/docs/SUMMARIZED-RD.md
+++ b/docs/SUMMARIZED-RD.md
@@ -118,3 +118,13 @@ User can filter the data with the following query params:
 - `endYear`
 - `isHistorical` -- whether or not to filter on just historical data
 - `isPrediction` -- whether or not to filter on just prediction data
+
+## `GET /summarized-rangerdistrict/rangerDistricts/results`
+
+Returns a list of sorted rangerdistrict names represented in the data.
+
+User can filter the data with the following query params:
+
+- `state`
+- `year`
+- `rangerDistrict`

--- a/src/routers/summarized-county.js
+++ b/src/routers/summarized-county.js
@@ -18,6 +18,7 @@ import {
   generateLocationListPipeline,
   specifiedQueryFetch,
   queryFetch,
+  getResults,
 } from '../utils';
 
 import {
@@ -311,6 +312,26 @@ summarizedCountyRouter.route('/counties/list')
       console.log(error);
 
       res.status(RESPONSE_CODES.INTERNAL_ERROR.status).send(
+        generateResponse(RESPONSE_TYPES.INTERNAL_ERROR, error),
+      );
+    }
+  });
+
+summarizedCountyRouter.route('/counties/results')
+  .get(async (req, res) => {
+    const {
+      year,
+      county,
+      state,
+    } = req.query;
+
+    try {
+      const counties = await getResults(COLLECTION_NAMES.summarizedCounty, { county, state, year });
+      return res.send(generateResponse(RESPONSE_TYPES.SUCCESS, counties));
+    } catch (error) {
+      console.log(error);
+
+      return res.status(RESPONSE_CODES.INTERNAL_ERROR.status).send(
         generateResponse(RESPONSE_TYPES.INTERNAL_ERROR, error),
       );
     }

--- a/src/routers/summarized-ranger-district.js
+++ b/src/routers/summarized-ranger-district.js
@@ -18,6 +18,7 @@ import {
   generateLocationListPipeline,
   specifiedQueryFetch,
   queryFetch,
+  getResults,
 } from '../utils';
 
 import {
@@ -311,6 +312,26 @@ summarizedRDRouter.route('/rangerDistricts/list')
       console.log(error);
 
       res.status(RESPONSE_CODES.INTERNAL_ERROR.status).send(
+        generateResponse(RESPONSE_TYPES.INTERNAL_ERROR, error),
+      );
+    }
+  });
+
+summarizedRDRouter.route('/rangerDistricts/results')
+  .get(async (req, res) => {
+    const {
+      year,
+      rangerDistrict,
+      state,
+    } = req.query;
+
+    try {
+      const rangerDistricts = await getResults(COLLECTION_NAMES.summarizedRangerDistrict, { rangerDistrict, state, year });
+      return res.send(generateResponse(RESPONSE_TYPES.SUCCESS, rangerDistricts));
+    } catch (error) {
+      console.log(error);
+
+      return res.status(RESPONSE_CODES.INTERNAL_ERROR.status).send(
         generateResponse(RESPONSE_TYPES.INTERNAL_ERROR, error),
       );
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -23,6 +23,8 @@ import {
   uploadFile,
 } from './upload-file';
 
+import getResults from './results';
+
 export {
   aggregate,
   generateLocationPipeline,
@@ -32,6 +34,7 @@ export {
   generateYearListPipeline,
   generateStateListPipeline,
   generateLocationListPipeline,
+  getResults,
   queryFetch,
   sendPasswordResetEmail,
   specifiedQueryFetch,

--- a/src/utils/results.js
+++ b/src/utils/results.js
@@ -1,0 +1,30 @@
+import { specifiedQueryFetch } from './query-fetch';
+
+const getResults = async (collectionName, filters = {}) => {
+  const currentYear = new Date().getFullYear();
+  const lastYear = currentYear - 1;
+
+  const records = await specifiedQueryFetch(collectionName, {
+    year: filters.year || lastYear,
+    hasPredictionAndOutcome: 1,
+    ...(filters.state ? { state: filters.state } : {}),
+    ...(filters.county ? { county: filters.county } : {}),
+    ...(filters.rangerDistrict ? { rangerDistrict: filters.rangerDistrict } : {}),
+  });
+
+  if (!records.length) {
+    return [];
+  }
+
+  return records.map((record) => {
+    return {
+      state: record.state,
+      county: record.county || undefined,
+      rangerDistrict: record.rangerDistrict || undefined,
+      probSpotsGT50: record.probSpotsGT50,
+      sumSpots: record.spotst0,
+    };
+  });
+};
+
+export default getResults;


### PR DESCRIPTION
# Description

Add `/summarized-county/counties/results` and `/summarized-rangerdistrict/rangerDistricts/results` endpoints which return data needed to compare predictions with actual data for given year.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [ ] Unit/integration tests
- [x] Documentation

## Tickets

- [Issue Number](Link)
